### PR TITLE
Emit on success

### DIFF
--- a/env.js
+++ b/env.js
@@ -15,7 +15,7 @@ module.exports = envalid.cleanEnv(process.env, {
     DATABASE_URL: envalid.str({default: 'DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres'}),
     HOST: envalid.host({ default: 'localhost' }),
     SERVER_PORT: envalid.port({ default: 4000, desc: 'The port to start the server on' }),
-    TRADER_PORT: envalid.port({ default: 8004, desc: 'The port to trader webserver runs' }),
+    TRADER_PORT: envalid.port({ default: 8003, desc: 'The port to trader webserver runs' }),
     STRATEGY_TIMEFRAME: envalid.str({default:'15m'}),
     VERSION: envalid.str({ default: pjson.version }),
 })

--- a/env.js
+++ b/env.js
@@ -15,7 +15,7 @@ module.exports = envalid.cleanEnv(process.env, {
     DATABASE_URL: envalid.str({default: 'DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres'}),
     HOST: envalid.host({ default: 'localhost' }),
     SERVER_PORT: envalid.port({ default: 4000, desc: 'The port to start the server on' }),
-    TRADER_PORT: envalid.port({ default: 8003, desc: 'The port to trader webserver runs' }),
+    TRADER_PORT: envalid.port({ default: 8004, desc: 'The port to trader webserver runs' }),
     STRATEGY_TIMEFRAME: envalid.str({default:'15m'}),
     VERSION: envalid.str({ default: pjson.version }),
 })

--- a/trader.js
+++ b/trader.js
@@ -8,7 +8,7 @@ const axios = require("axios")
 const Binance = require("node-binance-api")
 const nodemailer = require("nodemailer")
 //const TeleBot = require('telebot')
-const env = require('./env')
+const env = require("./env")
 
 const bva_key = env.BVA_API_KEY
 //const telegramToken = 'replaceWith:your_BOT_token' //BOT TOKEN -> ask BotFather Please if not use set default value to->> replaceWith:your_BOT_token
@@ -22,7 +22,6 @@ const gmailPassword = encodeURIComponent(gmail_app_password)
 const mailTransport = nodemailer.createTransport(
     `smtps://${gmailEmail}:${gmailPassword}@smtp.gmail.com`
 )
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //         VARIABLES TO KEEP TRACK OF BOT POSITIONS AND ACTIVITY
@@ -44,9 +43,7 @@ let minimums = {}
 
 const app = express()
 app.get("/", (req, res) => res.send(""))
-app.listen(env.TRADER_PORT, () =>
-    console.log("NBT auto trader running.".grey)
-)
+app.listen(env.TRADER_PORT, () => console.log("NBT auto trader running.".grey))
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -138,7 +135,7 @@ socket.on("buy_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => { })
+                    .then(() => {})
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -146,7 +143,7 @@ socket.on("buy_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => { })
+                                .then(() => {})
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -212,7 +209,7 @@ socket.on("buy_signal", async (signal) => {
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + "BTC"].minQty) {
                     const buy_amount = new BigNumber(
                         user_payload[tresult].buy_amount
                     )
@@ -245,7 +242,10 @@ socket.on("buy_signal", async (signal) => {
                                     }
 
                                     console.log("SUCCESS 222444222")
-                                    socket.emit("traded_buy_signal", traded_buy_signal)
+                                    socket.emit(
+                                        "traded_buy_signal",
+                                        traded_buy_signal
+                                    )
                                 }
                             )
                         } else {
@@ -268,7 +268,10 @@ socket.on("buy_signal", async (signal) => {
                                         alt + "BTC",
                                         Number(qty)
                                     )
-                                    socket.emit("traded_buy_signal", traded_buy_signal)
+                                    socket.emit(
+                                        "traded_buy_signal",
+                                        traded_buy_signal
+                                    )
                                 }
                             )
                         }
@@ -314,7 +317,7 @@ socket.on("buy_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => { })
+                    .then(() => {})
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -322,7 +325,7 @@ socket.on("buy_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => { })
+                                .then(() => {})
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -426,7 +429,10 @@ socket.on("buy_signal", async (signal) => {
                                     )
                                     return
                                 }
-                                socket.emit("traded_buy_signal", traded_buy_signal)
+                                socket.emit(
+                                    "traded_buy_signal",
+                                    traded_buy_signal
+                                )
 
                                 console.log("---+-- mgRepay ---+--")
                                 bnb_client.mgRepay(
@@ -507,7 +513,7 @@ socket.on("sell_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => { })
+                    .then(() => {})
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -515,7 +521,7 @@ socket.on("sell_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => { })
+                                .then(() => {})
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -584,7 +590,10 @@ socket.on("sell_signal", async (signal) => {
                                     console.log(
                                         "mgMarketSell BTCUSDT SUCCESS 2222"
                                     )
-                                    socket.emit("traded_sell_signal", traded_sell_signal)
+                                    socket.emit(
+                                        "traded_sell_signal",
+                                        traded_sell_signal
+                                    )
                                 }
                             )
                         }
@@ -596,7 +605,7 @@ socket.on("sell_signal", async (signal) => {
             } else {
                 console.log("const alt = signal.pair.replace('BTC', '')")
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + "BTC"].minQty) {
                     const buy_amount = new BigNumber(
                         user_payload[tresult].buy_amount
                     )
@@ -647,7 +656,10 @@ socket.on("sell_signal", async (signal) => {
                                             return
                                         }
                                         console.log("SUCCESS 22222222")
-                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                        socket.emit(
+                                            "traded_sell_signal",
+                                            traded_sell_signal
+                                        )
                                     }
                                 )
                             }
@@ -694,7 +706,7 @@ socket.on("sell_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => { })
+                    .then(() => {})
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -702,7 +714,7 @@ socket.on("sell_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => { })
+                                .then(() => {})
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -745,14 +757,17 @@ socket.on("sell_signal", async (signal) => {
                                     "ERROR 7220017 BTCUSDT",
                                     Number(
                                         trading_qty[
-                                        signal.pair + signal.stratid
+                                            signal.pair + signal.stratid
                                         ]
                                     ),
                                     JSON.stringify(error)
                                 )
                                 return
                             }
-                            socket.emit("traded_sell_signal", traded_sell_signal)
+                            socket.emit(
+                                "traded_sell_signal",
+                                traded_sell_signal
+                            )
                         }
                     )
                 } else {
@@ -761,7 +776,7 @@ socket.on("sell_signal", async (signal) => {
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + "BTC"].minQty) {
                     const qty = trading_qty[signal.pair + signal.stratid]
                     ///
                     const traded_sell_signal = {
@@ -777,10 +792,10 @@ socket.on("sell_signal", async (signal) => {
                         if (margin_pairs.includes(alt + "BTC")) {
                             console.log(
                                 "QTY =======mgMarketSell======> " +
-                                qty +
-                                " - " +
-                                alt +
-                                "BTC"
+                                    qty +
+                                    " - " +
+                                    alt +
+                                    "BTC"
                             )
                             bnb_client.mgMarketSell(
                                 alt + "BTC",
@@ -800,16 +815,19 @@ socket.on("sell_signal", async (signal) => {
                                         alt,
                                         Number(qty)
                                     )
-                                    socket.emit("traded_sell_signal", traded_sell_signal)
+                                    socket.emit(
+                                        "traded_sell_signal",
+                                        traded_sell_signal
+                                    )
                                 }
                             )
                         } else {
                             console.log(
                                 "QTY =======marketSell======> " +
-                                qty +
-                                " - " +
-                                alt +
-                                "BTC"
+                                    qty +
+                                    " - " +
+                                    alt +
+                                    "BTC"
                             )
                             bnb_client.marketSell(
                                 alt + "BTC",
@@ -829,7 +847,10 @@ socket.on("sell_signal", async (signal) => {
                                         alt + "BTC",
                                         Number(qty)
                                     )
-                                    socket.emit("traded_sell_signal", traded_sell_signal)
+                                    socket.emit(
+                                        "traded_sell_signal",
+                                        traded_sell_signal
+                                    )
                                 }
                             )
                         }
@@ -909,21 +930,24 @@ socket.on("close_traded_signal", async (signal) => {
                                 )
                                 return
                             }
-                            socket.emit("traded_sell_signal", traded_sell_signal)
+                            socket.emit(
+                                "traded_sell_signal",
+                                traded_sell_signal
+                            )
                         }
                     )
                 } else {
                     const alt = signal.pair.replace("BTC", "")
-                    if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
+                    if (minimums[alt + "BTC"] && minimums[alt + "BTC"].minQty) {
                         const qty = signal.qty
                         ///
                         if (margin_pairs.includes(alt + "BTC")) {
                             console.log(
                                 "CLOSE =========mgMarketSell=========> " +
-                                qty +
-                                " - " +
-                                alt +
-                                "BTC"
+                                    qty +
+                                    " - " +
+                                    alt +
+                                    "BTC"
                             )
                             bnb_client.mgMarketSell(
                                 alt + "BTC",
@@ -938,21 +962,20 @@ socket.on("close_traded_signal", async (signal) => {
                                         )
                                         return
                                     }
-                                    console.log(
-                                        "SUCESS44444",
-                                        alt,
-                                        Number(qty)
+                                    console.log("SUCESS44444", alt, Number(qty))
+                                    socket.emit(
+                                        "traded_sell_signal",
+                                        traded_sell_signal
                                     )
-                                    socket.emit("traded_sell_signal", traded_sell_signal)
                                 }
                             )
                         } else {
                             console.log(
                                 "CLOSE =========marketSell=========> " +
-                                qty +
-                                " - " +
-                                alt +
-                                "BTC"
+                                    qty +
+                                    " - " +
+                                    alt +
+                                    "BTC"
                             )
                             bnb_client.marketSell(
                                 alt + "BTC",
@@ -972,7 +995,10 @@ socket.on("close_traded_signal", async (signal) => {
                                         alt,
                                         Number(qty)
                                     )
-                                    socket.emit("traded_sell_signal", traded_sell_signal)
+                                    socket.emit(
+                                        "traded_sell_signal",
+                                        traded_sell_signal
+                                    )
                                 }
                             )
                         }
@@ -1048,7 +1074,7 @@ socket.on("close_traded_signal", async (signal) => {
                     )
                 } else {
                     const alt = signal.pair.replace("BTC", "")
-                    if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
+                    if (minimums[alt + "BTC"] && minimums[alt + "BTC"].minQty) {
                         const qty = trading_qty[signal.pair + signal.stratid]
                         console.log("QTY ==> " + qty + " - " + alt + "BTC")
                         bnb_client.mgMarketBuy(
@@ -1066,7 +1092,10 @@ socket.on("close_traded_signal", async (signal) => {
                                     )
                                     return
                                 }
-                                socket.emit("traded_buy_signal", traded_buy_signal)
+                                socket.emit(
+                                    "traded_buy_signal",
+                                    traded_buy_signal
+                                )
 
                                 console.log("----- mgRepay -----")
                                 bnb_client.mgRepay(
@@ -1082,9 +1111,7 @@ socket.on("close_traded_signal", async (signal) => {
                                             )
                                             return
                                         }
-                                        console.log(
-                                            "SUCCESS 888888888888"
-                                        )
+                                        console.log("SUCCESS 888888888888")
                                     }
                                 )
                             }
@@ -1195,7 +1222,7 @@ async function UpdateOpenTrades() {
         axios
             .get(
                 "https://bitcoinvsaltcoins.com/api/useropentradedsignals?key=" +
-                bva_key
+                    bva_key
             )
             .then((response) => {
                 response.data.rows.map((s) => {

--- a/trader.js
+++ b/trader.js
@@ -138,7 +138,7 @@ socket.on("buy_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => {})
+                    .then(() => { })
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -146,7 +146,7 @@ socket.on("buy_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => {})
+                                .then(() => { })
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -193,12 +193,13 @@ socket.on("buy_signal", async (signal) => {
                         "BTCUSDT",
                         Number(user_payload[tresult].buy_amount),
                         (error, response) => {
-                            if (error)
+                            if (error) {
                                 console.log(
                                     "ERROR 3 BTCUSDT ",
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
+                            }
                             if (response) {
                                 console.log(" mgMarketBuy BTCUSDT SUCESS 3")
                                 socket.emit("traded_buy_signal", traded_buy_signal)
@@ -211,7 +212,7 @@ socket.on("buy_signal", async (signal) => {
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt+'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
                     const buy_amount = new BigNumber(
                         user_payload[tresult].buy_amount
                     )
@@ -311,7 +312,7 @@ socket.on("buy_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => {})
+                    .then(() => { })
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -319,7 +320,7 @@ socket.on("buy_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => {})
+                                .then(() => { })
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -361,10 +362,11 @@ socket.on("buy_signal", async (signal) => {
                         "BTCUSDT",
                         qty,
                         (error, response) => {
-                            if (error)
+                            if (error) {
                                 console.log("ERROR 5 BTCUST ", qty, error.body)
-                            else 
+                            } else {
                                 socket.emit("traded_buy_signal", traded_buy_signal)
+                            }
 
                             if (response) {
                                 console.log("----- mgRepay BTC 5 -----")
@@ -372,13 +374,15 @@ socket.on("buy_signal", async (signal) => {
                                     "BTC",
                                     qty,
                                     (error, response) => {
-                                        if (error)
+                                        if (error) {
                                             console.log(
                                                 "ERROR BTC 999",
                                                 qty,
                                                 error.body
                                             )
-                                        else console.log("SUCCESS BTC 888")
+                                        } else {
+                                            console.log("SUCCESS BTC 888")
+                                        }
                                     }
                                 )
                             }
@@ -412,15 +416,16 @@ socket.on("buy_signal", async (signal) => {
                             alt + "BTC",
                             Number(qty),
                             (error, response) => {
-                                if (error)
+                                if (error) {
                                     console.log(
                                         "ERROR 6 ",
                                         alt,
                                         Number(qty),
                                         error.body
                                     )
-                                else
+                                } else {
                                     socket.emit("traded_buy_signal", traded_buy_signal)
+                                }
 
                                 if (response) {
                                     console.log("---+-- mgRepay ---+--")
@@ -428,15 +433,16 @@ socket.on("buy_signal", async (signal) => {
                                         alt,
                                         Number(qty),
                                         (error, response) => {
-                                            if (error)
+                                            if (error) {
                                                 console.log(
                                                     "ERROR 244343333",
                                                     alt,
                                                     Number(qty),
                                                     error.body
                                                 )
-                                            else
+                                            } else {
                                                 console.log("SUCCESS 333342111")
+                                            }
                                         }
                                     )
                                 }
@@ -502,7 +508,7 @@ socket.on("sell_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => {})
+                    .then(() => { })
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -510,7 +516,7 @@ socket.on("sell_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => {})
+                                .then(() => { })
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -550,35 +556,35 @@ socket.on("sell_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(user_payload[tresult].buy_amount),
                 }
-                
+
                 if (user_payload[tresult].trading_type === "real") {
                     bnb_client.mgBorrow(
                         "BTC",
                         Number(user_payload[tresult].buy_amount),
                         (error, response) => {
-                            if (error)
+                            if (error) {
                                 console.log(
                                     "ERROR BTC 55",
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
-                            else {
+                            } else {
                                 console.log("SUCESS BTC 4 mgMarketSell 444")
                                 bnb_client.mgMarketSell(
                                     "BTCUSDT",
                                     Number(user_payload[tresult].buy_amount),
                                     (error, response) => {
-                                        if (error)
+                                        if (error) {
                                             console.log(
                                                 "ERROR BTC 33333",
                                                 error.body
                                             )
-                                        else{
+                                        } else {
                                             console.log(
                                                 "mgMarketSell BTCUSDT SUCCESS 2222"
                                             )
                                             socket.emit("traded_sell_signal", traded_sell_signal)
-                                        }    
+                                        }
                                     }
                                 )
                             }
@@ -591,7 +597,7 @@ socket.on("sell_signal", async (signal) => {
             } else {
                 console.log("const alt = signal.pair.replace('BTC', '')")
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt+'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
                     const buy_amount = new BigNumber(
                         user_payload[tresult].buy_amount
                     )
@@ -612,7 +618,7 @@ socket.on("sell_signal", async (signal) => {
                         pair: signal.pair,
                         qty: qty,
                     }
-                    
+
                     if (user_payload[tresult].trading_type === "real") {
                         bnb_client.mgBorrow(
                             alt,
@@ -633,12 +639,12 @@ socket.on("sell_signal", async (signal) => {
                                         alt + "BTC",
                                         Number(qty),
                                         (error, response) => {
-                                            if (error)
+                                            if (error) {
                                                 console.log(
                                                     "ERROR 333333333",
                                                     JSON.stringify(error)
                                                 )
-                                            else {
+                                            } else {
                                                 console.log("SUCCESS 22222222")
                                                 socket.emit("traded_sell_signal", traded_sell_signal)
                                             }
@@ -689,7 +695,7 @@ socket.on("sell_signal", async (signal) => {
                 }
                 mailTransport
                     .sendMail(mailOptions)
-                    .then(() => {})
+                    .then(() => { })
                     .catch((error) => {
                         console.error(
                             "There was an error while sending the email ... trying again..."
@@ -697,7 +703,7 @@ socket.on("sell_signal", async (signal) => {
                         setTimeout(() => {
                             mailTransport
                                 .sendMail(mailOptions)
-                                .then(() => {})
+                                .then(() => { })
                                 .catch((error) => {
                                     console.error(
                                         "There was an error while sending the email: stop trying"
@@ -729,7 +735,7 @@ socket.on("sell_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(trading_qty[signal.pair + signal.stratid]),
                 }
-                
+
                 if (user_payload[tresult].trading_type === "real") {
                     bnb_client.mgMarketSell(
                         "BTCUSDT",
@@ -740,7 +746,7 @@ socket.on("sell_signal", async (signal) => {
                                     "ERROR 7220017 BTCUSDT",
                                     Number(
                                         trading_qty[
-                                            signal.pair + signal.stratid
+                                        signal.pair + signal.stratid
                                         ]
                                     ),
                                     JSON.stringify(error)
@@ -756,7 +762,7 @@ socket.on("sell_signal", async (signal) => {
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
-                if (minimums[alt + "BTC"] && minimums[alt+'BTC'].minQty) {
+                if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
                     const qty = trading_qty[signal.pair + signal.stratid]
                     ///
                     const traded_sell_signal = {
@@ -772,10 +778,10 @@ socket.on("sell_signal", async (signal) => {
                         if (margin_pairs.includes(alt + "BTC")) {
                             console.log(
                                 "QTY =======mgMarketSell======> " +
-                                    qty +
-                                    " - " +
-                                    alt +
-                                    "BTC"
+                                qty +
+                                " - " +
+                                alt +
+                                "BTC"
                             )
                             bnb_client.mgMarketSell(
                                 alt + "BTC",
@@ -801,10 +807,10 @@ socket.on("sell_signal", async (signal) => {
                         } else {
                             console.log(
                                 "QTY =======marketSell======> " +
-                                    qty +
-                                    " - " +
-                                    alt +
-                                    "BTC"
+                                qty +
+                                " - " +
+                                alt +
+                                "BTC"
                             )
                             bnb_client.marketSell(
                                 alt + "BTC",
@@ -909,16 +915,16 @@ socket.on("close_traded_signal", async (signal) => {
                     )
                 } else {
                     const alt = signal.pair.replace("BTC", "")
-                    if (minimums[alt + "BTC"] && minimums[alt+'BTC'].minQty) {
+                    if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
                         const qty = signal.qty
                         ///
                         if (margin_pairs.includes(alt + "BTC")) {
                             console.log(
                                 "CLOSE =========mgMarketSell=========> " +
-                                    qty +
-                                    " - " +
-                                    alt +
-                                    "BTC"
+                                qty +
+                                " - " +
+                                alt +
+                                "BTC"
                             )
                             bnb_client.mgMarketSell(
                                 alt + "BTC",
@@ -944,10 +950,10 @@ socket.on("close_traded_signal", async (signal) => {
                         } else {
                             console.log(
                                 "CLOSE =========marketSell=========> " +
-                                    qty +
-                                    " - " +
-                                    alt +
-                                    "BTC"
+                                qty +
+                                " - " +
+                                alt +
+                                "BTC"
                             )
                             bnb_client.marketSell(
                                 alt + "BTC",
@@ -1013,14 +1019,15 @@ socket.on("close_traded_signal", async (signal) => {
                         "BTCUSDT",
                         signal.qty,
                         (error, response) => {
-                            if (error)
+                            if (error) {
                                 console.log(
                                     "ERROR 990099 BTCUSDT",
                                     Number(signal.qty),
                                     error.body
                                 )
-                            else
+                            } else {
                                 socket.emit("traded_buy_signal", traded_buy_signal)
+                            }
 
                             if (response) {
                                 console.log("----- mgRepay BTC -----")
@@ -1028,13 +1035,15 @@ socket.on("close_traded_signal", async (signal) => {
                                     "BTC",
                                     Number(signal.qty),
                                     (error, response) => {
-                                        if (error)
+                                        if (error) {
                                             console.log(
                                                 "ERROR BTC 9",
                                                 Number(signal.qty),
                                                 error.body
                                             )
-                                        else console.log("SUCCESS BTC 8")
+                                        } else {
+                                            console.log("SUCCESS BTC 8")
+                                        }
                                     }
                                 )
                             }
@@ -1042,7 +1051,7 @@ socket.on("close_traded_signal", async (signal) => {
                     )
                 } else {
                     const alt = signal.pair.replace("BTC", "")
-                    if (minimums[alt + "BTC"] && minimums[alt+'BTC'].minQty) {
+                    if (minimums[alt + "BTC"] && minimums[alt + 'BTC'].minQty) {
                         const qty = trading_qty[signal.pair + signal.stratid]
                         console.log("QTY ==> " + qty + " - " + alt + "BTC")
                         bnb_client.mgMarketBuy(
@@ -1058,7 +1067,7 @@ socket.on("close_traded_signal", async (signal) => {
                                         ),
                                         error.body
                                     )
-                                } else 
+                                } else
                                     socket.emit("traded_buy_signal", traded_buy_signal)
 
                                 if (response) {
@@ -1067,17 +1076,18 @@ socket.on("close_traded_signal", async (signal) => {
                                         alt,
                                         Number(qty),
                                         (error, response) => {
-                                            if (error)
+                                            if (error) {
                                                 console.log(
                                                     "ERROR 99999999999",
                                                     alt,
                                                     Number(qty),
                                                     error.body
                                                 )
-                                            else
+                                            } else {
                                                 console.log(
                                                     "SUCCESS 888888888888"
                                                 )
+                                            }
                                         }
                                     )
                                 }
@@ -1189,7 +1199,7 @@ async function UpdateOpenTrades() {
         axios
             .get(
                 "https://bitcoinvsaltcoins.com/api/useropentradedsignals?key=" +
-                    bva_key
+                bva_key
             )
             .then((response) => {
                 response.data.rows.map((s) => {

--- a/trader.js
+++ b/trader.js
@@ -187,7 +187,6 @@ socket.on("buy_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(user_payload[tresult].buy_amount),
                 }
-                socket.emit("traded_buy_signal", traded_buy_signal)
                 ////
                 if (user_payload[tresult].trading_type === "real") {
                     bnb_client.mgMarketBuy(
@@ -200,10 +199,15 @@ socket.on("buy_signal", async (signal) => {
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
-                            if (response)
+                            if (response) {
                                 console.log(" mgMarketBuy BTCUSDT SUCESS 3")
+                                socket.emit("traded_buy_signal", traded_buy_signal)
+                            }
                         }
                     )
+                } else {
+                    // VIRTUAL TRADE
+                    socket.emit("traded_buy_signal", traded_buy_signal)
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
@@ -227,7 +231,6 @@ socket.on("buy_signal", async (signal) => {
                         pair: signal.pair,
                         qty: qty,
                     }
-                    socket.emit("traded_buy_signal", traded_buy_signal)
                     ////
                     if (user_payload[tresult].trading_type === "real") {
                         if (margin_pairs.includes(alt + "BTC")) {
@@ -262,6 +265,9 @@ socket.on("buy_signal", async (signal) => {
                                 }
                             )
                         }
+                    } else {
+                        // VIRTUAL TRADE
+                        socket.emit("traded_buy_signal", traded_buy_signal)
                     }
                 } else {
                     console.log("PAIR UNKNOWN", alt)
@@ -342,7 +348,6 @@ socket.on("buy_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(trading_qty[signal.pair + signal.stratid]),
                 }
-                socket.emit("traded_buy_signal", traded_buy_signal)
                 /////
                 if (user_payload[tresult].trading_type === "real") {
                     const qty = Number(
@@ -372,6 +377,9 @@ socket.on("buy_signal", async (signal) => {
                             }
                         }
                     )
+                } else {
+                    // VIRTUAL TRADE
+                    socket.emit("traded_buy_signal", traded_buy_signal)
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
@@ -391,7 +399,6 @@ socket.on("buy_signal", async (signal) => {
                         pair: signal.pair,
                         qty: qty,
                     }
-                    socket.emit("traded_buy_signal", traded_buy_signal)
                     /////
                     if (user_payload[tresult].trading_type === "real") {
                         bnb_client.mgMarketBuy(
@@ -425,6 +432,9 @@ socket.on("buy_signal", async (signal) => {
                                 }
                             }
                         )
+                    } else {
+                        // VIRTUAL TRADE
+                        socket.emit("traded_buy_signal", traded_buy_signal)
                     }
                 } else {
                     console.log("PAIR UNKNOWN", alt)
@@ -530,7 +540,7 @@ socket.on("sell_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(user_payload[tresult].buy_amount),
                 }
-                socket.emit("traded_sell_signal", traded_sell_signal)
+                
                 if (user_payload[tresult].trading_type === "real") {
                     bnb_client.mgBorrow(
                         "BTC",
@@ -562,6 +572,9 @@ socket.on("sell_signal", async (signal) => {
                             }
                         }
                     )
+                } else {
+                    // VIRTUAL TRADE
+                    socket.emit("traded_sell_signal", traded_sell_signal)
                 }
             } else {
                 console.log("const alt = signal.pair.replace('BTC', '')")
@@ -587,7 +600,7 @@ socket.on("sell_signal", async (signal) => {
                         pair: signal.pair,
                         qty: qty,
                     }
-                    socket.emit("traded_sell_signal", traded_sell_signal)
+                    
                     if (user_payload[tresult].trading_type === "real") {
                         bnb_client.mgBorrow(
                             alt,
@@ -619,6 +632,9 @@ socket.on("sell_signal", async (signal) => {
                                 }
                             }
                         )
+                    } else {
+                        // VIRTUAL TRADE
+                        socket.emit("traded_sell_signal", traded_sell_signal)
                     }
                 } else {
                     console.log("PAIR UNKNOWN", alt)
@@ -698,7 +714,7 @@ socket.on("sell_signal", async (signal) => {
                     pair: signal.pair,
                     qty: Number(trading_qty[signal.pair + signal.stratid]),
                 }
-                socket.emit("traded_sell_signal", traded_sell_signal)
+                
                 if (user_payload[tresult].trading_type === "real") {
                     bnb_client.mgMarketSell(
                         "BTCUSDT",
@@ -717,6 +733,9 @@ socket.on("sell_signal", async (signal) => {
                             }
                         }
                     )
+                } else {
+                    // VIRTUAL TRADE
+                    socket.emit("traded_sell_signal", traded_sell_signal)
                 }
             } else {
                 const alt = signal.pair.replace("BTC", "")
@@ -731,7 +750,6 @@ socket.on("sell_signal", async (signal) => {
                         pair: signal.pair,
                         qty: qty,
                     }
-                    socket.emit("traded_sell_signal", traded_sell_signal)
                     ///
                     if (user_payload[tresult].trading_type === "real") {
                         if (margin_pairs.includes(alt + "BTC")) {
@@ -791,6 +809,9 @@ socket.on("sell_signal", async (signal) => {
                                 }
                             )
                         }
+                    } else {
+                        // VIRTUAL TRADE
+                        socket.emit("traded_sell_signal", traded_sell_signal)
                     }
                     ///
                 } else {
@@ -848,7 +869,6 @@ socket.on("close_traded_signal", async (signal) => {
                 pair: signal.pair,
                 qty: signal.qty,
             }
-            socket.emit("traded_sell_signal", traded_sell_signal)
             //////
             if (user_payload[tresult].trading_type === "real") {
                 console.log(signal.pair, " ===---==> SELL ", signal.qty)
@@ -933,6 +953,9 @@ socket.on("close_traded_signal", async (signal) => {
                         console.log("PAIR UNKNOWN", alt)
                     }
                 }
+            } else {
+                // VIRTUAL TRADE
+                socket.emit("traded_sell_signal", traded_sell_signal)
             }
             //////
             delete trading_pairs[signal.pair + signal.stratid]
@@ -959,7 +982,6 @@ socket.on("close_traded_signal", async (signal) => {
                 pair: signal.pair,
                 qty: signal.qty,
             }
-            socket.emit("traded_buy_signal", traded_buy_signal)
             //////
             if (user_payload[tresult].trading_type === "real") {
                 console.log(signal.pair, " ---==---> BUY ", signal.qty)
@@ -1037,6 +1059,9 @@ socket.on("close_traded_signal", async (signal) => {
                         console.log("PAIR UNKNOWN", alt)
                     }
                 }
+            } else {
+                // VIRTUAL TRADE
+                socket.emit("traded_buy_signal", traded_buy_signal)
             }
             //////
             delete trading_pairs[signal.pair + signal.stratid]

--- a/trader.js
+++ b/trader.js
@@ -240,7 +240,10 @@ socket.on("buy_signal", async (signal) => {
                                 (error, response) => {
                                     if (error) {
                                         console.log("ERROR 3355333", error.body)
-                                    } else console.log("SUCCESS 222444222")
+                                    } else {
+                                        console.log("SUCCESS 222444222")
+                                        socket.emit("traded_buy_signal", traded_buy_signal)
+                                    }
                                 }
                             )
                         } else {
@@ -261,6 +264,7 @@ socket.on("buy_signal", async (signal) => {
                                             alt + "BTC",
                                             Number(qty)
                                         )
+                                        socket.emit("traded_buy_signal", traded_buy_signal)
                                     }
                                 }
                             )
@@ -359,6 +363,9 @@ socket.on("buy_signal", async (signal) => {
                         (error, response) => {
                             if (error)
                                 console.log("ERROR 5 BTCUST ", qty, error.body)
+                            else 
+                                socket.emit("traded_buy_signal", traded_buy_signal)
+
                             if (response) {
                                 console.log("----- mgRepay BTC 5 -----")
                                 bnb_client.mgRepay(
@@ -412,6 +419,9 @@ socket.on("buy_signal", async (signal) => {
                                         Number(qty),
                                         error.body
                                     )
+                                else
+                                    socket.emit("traded_buy_signal", traded_buy_signal)
+
                                 if (response) {
                                     console.log("---+-- mgRepay ---+--")
                                     bnb_client.mgRepay(
@@ -563,10 +573,12 @@ socket.on("sell_signal", async (signal) => {
                                                 "ERROR BTC 33333",
                                                 error.body
                                             )
-                                        else
+                                        else{
                                             console.log(
                                                 "mgMarketSell BTCUSDT SUCCESS 2222"
                                             )
+                                            socket.emit("traded_sell_signal", traded_sell_signal)
+                                        }    
                                     }
                                 )
                             }
@@ -626,7 +638,10 @@ socket.on("sell_signal", async (signal) => {
                                                     "ERROR 333333333",
                                                     JSON.stringify(error)
                                                 )
-                                            else console.log("SUCCESS 22222222")
+                                            else {
+                                                console.log("SUCCESS 22222222")
+                                                socket.emit("traded_sell_signal", traded_sell_signal)
+                                            }
                                         }
                                     )
                                 }
@@ -730,6 +745,8 @@ socket.on("sell_signal", async (signal) => {
                                     ),
                                     JSON.stringify(error)
                                 )
+                            } else {
+                                socket.emit("traded_sell_signal", traded_sell_signal)
                             }
                         }
                     )
@@ -777,6 +794,7 @@ socket.on("sell_signal", async (signal) => {
                                             alt,
                                             Number(qty)
                                         )
+                                        socket.emit("traded_sell_signal", traded_sell_signal)
                                     }
                                 }
                             )
@@ -805,6 +823,7 @@ socket.on("sell_signal", async (signal) => {
                                             alt + "BTC",
                                             Number(qty)
                                         )
+                                        socket.emit("traded_sell_signal", traded_sell_signal)
                                     }
                                 }
                             )
@@ -883,6 +902,8 @@ socket.on("close_traded_signal", async (signal) => {
                                     Number(signal.qty),
                                     JSON.stringify(error)
                                 )
+                            } else {
+                                socket.emit("traded_sell_signal", traded_sell_signal)
                             }
                         }
                     )
@@ -916,6 +937,7 @@ socket.on("close_traded_signal", async (signal) => {
                                             alt,
                                             Number(qty)
                                         )
+                                        socket.emit("traded_sell_signal", traded_sell_signal)
                                     }
                                 }
                             )
@@ -944,6 +966,7 @@ socket.on("close_traded_signal", async (signal) => {
                                             alt,
                                             Number(qty)
                                         )
+                                        socket.emit("traded_sell_signal", traded_sell_signal)
                                     }
                                 }
                             )
@@ -996,6 +1019,9 @@ socket.on("close_traded_signal", async (signal) => {
                                     Number(signal.qty),
                                     error.body
                                 )
+                            else
+                                socket.emit("traded_buy_signal", traded_buy_signal)
+
                             if (response) {
                                 console.log("----- mgRepay BTC -----")
                                 bnb_client.mgRepay(
@@ -1032,7 +1058,9 @@ socket.on("close_traded_signal", async (signal) => {
                                         ),
                                         error.body
                                     )
-                                }
+                                } else 
+                                    socket.emit("traded_buy_signal", traded_buy_signal)
+
                                 if (response) {
                                     console.log("----- mgRepay -----")
                                     bnb_client.mgRepay(

--- a/trader.js
+++ b/trader.js
@@ -199,8 +199,7 @@ socket.on("buy_signal", async (signal) => {
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
-                            }
-                            if (response) {
+                            } else {
                                 console.log(" mgMarketBuy BTCUSDT SUCESS 3")
                                 socket.emit("traded_buy_signal", traded_buy_signal)
                             }
@@ -366,9 +365,7 @@ socket.on("buy_signal", async (signal) => {
                                 console.log("ERROR 5 BTCUST ", qty, error.body)
                             } else {
                                 socket.emit("traded_buy_signal", traded_buy_signal)
-                            }
 
-                            if (response) {
                                 console.log("----- mgRepay BTC 5 -----")
                                 bnb_client.mgRepay(
                                     "BTC",
@@ -425,9 +422,7 @@ socket.on("buy_signal", async (signal) => {
                                     )
                                 } else {
                                     socket.emit("traded_buy_signal", traded_buy_signal)
-                                }
-
-                                if (response) {
+  
                                     console.log("---+-- mgRepay ---+--")
                                     bnb_client.mgRepay(
                                         alt,
@@ -1027,9 +1022,7 @@ socket.on("close_traded_signal", async (signal) => {
                                 )
                             } else {
                                 socket.emit("traded_buy_signal", traded_buy_signal)
-                            }
 
-                            if (response) {
                                 console.log("----- mgRepay BTC -----")
                                 bnb_client.mgRepay(
                                     "BTC",
@@ -1070,7 +1063,6 @@ socket.on("close_traded_signal", async (signal) => {
                                 } else
                                     socket.emit("traded_buy_signal", traded_buy_signal)
 
-                                if (response) {
                                     console.log("----- mgRepay -----")
                                     bnb_client.mgRepay(
                                         alt,

--- a/trader.js
+++ b/trader.js
@@ -422,7 +422,7 @@ socket.on("buy_signal", async (signal) => {
                                     )
                                 } else {
                                     socket.emit("traded_buy_signal", traded_buy_signal)
-  
+
                                     console.log("---+-- mgRepay ---+--")
                                     bnb_client.mgRepay(
                                         alt,
@@ -1060,7 +1060,7 @@ socket.on("close_traded_signal", async (signal) => {
                                         ),
                                         error.body
                                     )
-                                } else
+                                } else {
                                     socket.emit("traded_buy_signal", traded_buy_signal)
 
                                     console.log("----- mgRepay -----")

--- a/trader.js
+++ b/trader.js
@@ -199,10 +199,11 @@ socket.on("buy_signal", async (signal) => {
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
-                            } else {
-                                console.log(" mgMarketBuy BTCUSDT SUCESS 3")
-                                socket.emit("traded_buy_signal", traded_buy_signal)
+                                return
                             }
+
+                            console.log(" mgMarketBuy BTCUSDT SUCESS 3")
+                            socket.emit("traded_buy_signal", traded_buy_signal)
                         }
                     )
                 } else {
@@ -240,10 +241,11 @@ socket.on("buy_signal", async (signal) => {
                                 (error, response) => {
                                     if (error) {
                                         console.log("ERROR 3355333", error.body)
-                                    } else {
-                                        console.log("SUCCESS 222444222")
-                                        socket.emit("traded_buy_signal", traded_buy_signal)
+                                        return
                                     }
+
+                                    console.log("SUCCESS 222444222")
+                                    socket.emit("traded_buy_signal", traded_buy_signal)
                                 }
                             )
                         } else {
@@ -258,14 +260,15 @@ socket.on("buy_signal", async (signal) => {
                                             Number(qty),
                                             error.body
                                         )
-                                    } else {
-                                        console.log(
-                                            "SUCESS 99111 marketBuy",
-                                            alt + "BTC",
-                                            Number(qty)
-                                        )
-                                        socket.emit("traded_buy_signal", traded_buy_signal)
+                                        return
                                     }
+
+                                    console.log(
+                                        "SUCESS 99111 marketBuy",
+                                        alt + "BTC",
+                                        Number(qty)
+                                    )
+                                    socket.emit("traded_buy_signal", traded_buy_signal)
                                 }
                             )
                         }
@@ -363,26 +366,27 @@ socket.on("buy_signal", async (signal) => {
                         (error, response) => {
                             if (error) {
                                 console.log("ERROR 5 BTCUST ", qty, error.body)
-                            } else {
-                                socket.emit("traded_buy_signal", traded_buy_signal)
-
-                                console.log("----- mgRepay BTC 5 -----")
-                                bnb_client.mgRepay(
-                                    "BTC",
-                                    qty,
-                                    (error, response) => {
-                                        if (error) {
-                                            console.log(
-                                                "ERROR BTC 999",
-                                                qty,
-                                                error.body
-                                            )
-                                        } else {
-                                            console.log("SUCCESS BTC 888")
-                                        }
-                                    }
-                                )
+                                return
                             }
+
+                            socket.emit("traded_buy_signal", traded_buy_signal)
+
+                            console.log("----- mgRepay BTC 5 -----")
+                            bnb_client.mgRepay(
+                                "BTC",
+                                qty,
+                                (error, response) => {
+                                    if (error) {
+                                        console.log(
+                                            "ERROR BTC 999",
+                                            qty,
+                                            error.body
+                                        )
+                                        return
+                                    }
+                                    console.log("SUCCESS BTC 888")
+                                }
+                            )
                         }
                     )
                 } else {
@@ -420,27 +424,27 @@ socket.on("buy_signal", async (signal) => {
                                         Number(qty),
                                         error.body
                                     )
-                                } else {
-                                    socket.emit("traded_buy_signal", traded_buy_signal)
-
-                                    console.log("---+-- mgRepay ---+--")
-                                    bnb_client.mgRepay(
-                                        alt,
-                                        Number(qty),
-                                        (error, response) => {
-                                            if (error) {
-                                                console.log(
-                                                    "ERROR 244343333",
-                                                    alt,
-                                                    Number(qty),
-                                                    error.body
-                                                )
-                                            } else {
-                                                console.log("SUCCESS 333342111")
-                                            }
-                                        }
-                                    )
+                                    return
                                 }
+                                socket.emit("traded_buy_signal", traded_buy_signal)
+
+                                console.log("---+-- mgRepay ---+--")
+                                bnb_client.mgRepay(
+                                    alt,
+                                    Number(qty),
+                                    (error, response) => {
+                                        if (error) {
+                                            console.log(
+                                                "ERROR 244343333",
+                                                alt,
+                                                Number(qty),
+                                                error.body
+                                            )
+                                            return
+                                        }
+                                        console.log("SUCCESS 333342111")
+                                    }
+                                )
                             }
                         )
                     } else {
@@ -563,26 +567,26 @@ socket.on("sell_signal", async (signal) => {
                                     Number(user_payload[tresult].buy_amount),
                                     error.body
                                 )
-                            } else {
-                                console.log("SUCESS BTC 4 mgMarketSell 444")
-                                bnb_client.mgMarketSell(
-                                    "BTCUSDT",
-                                    Number(user_payload[tresult].buy_amount),
-                                    (error, response) => {
-                                        if (error) {
-                                            console.log(
-                                                "ERROR BTC 33333",
-                                                error.body
-                                            )
-                                        } else {
-                                            console.log(
-                                                "mgMarketSell BTCUSDT SUCCESS 2222"
-                                            )
-                                            socket.emit("traded_sell_signal", traded_sell_signal)
-                                        }
-                                    }
-                                )
+                                return
                             }
+                            console.log("SUCESS BTC 4 mgMarketSell 444")
+                            bnb_client.mgMarketSell(
+                                "BTCUSDT",
+                                Number(user_payload[tresult].buy_amount),
+                                (error, response) => {
+                                    if (error) {
+                                        console.log(
+                                            "ERROR BTC 33333",
+                                            error.body
+                                        )
+                                        return
+                                    }
+                                    console.log(
+                                        "mgMarketSell BTCUSDT SUCCESS 2222"
+                                    )
+                                    socket.emit("traded_sell_signal", traded_sell_signal)
+                                }
+                            )
                         }
                     )
                 } else {
@@ -626,26 +630,26 @@ socket.on("sell_signal", async (signal) => {
                                         Number(qty),
                                         JSON.stringify(error)
                                     )
-                                } else {
-                                    console.log(
-                                        "SUCESS 444444444 mgMarketSell 44444444"
-                                    )
-                                    bnb_client.mgMarketSell(
-                                        alt + "BTC",
-                                        Number(qty),
-                                        (error, response) => {
-                                            if (error) {
-                                                console.log(
-                                                    "ERROR 333333333",
-                                                    JSON.stringify(error)
-                                                )
-                                            } else {
-                                                console.log("SUCCESS 22222222")
-                                                socket.emit("traded_sell_signal", traded_sell_signal)
-                                            }
-                                        }
-                                    )
+                                    return
                                 }
+                                console.log(
+                                    "SUCESS 444444444 mgMarketSell 44444444"
+                                )
+                                bnb_client.mgMarketSell(
+                                    alt + "BTC",
+                                    Number(qty),
+                                    (error, response) => {
+                                        if (error) {
+                                            console.log(
+                                                "ERROR 333333333",
+                                                JSON.stringify(error)
+                                            )
+                                            return
+                                        }
+                                        console.log("SUCCESS 22222222")
+                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                    }
+                                )
                             }
                         )
                     } else {
@@ -746,9 +750,9 @@ socket.on("sell_signal", async (signal) => {
                                     ),
                                     JSON.stringify(error)
                                 )
-                            } else {
-                                socket.emit("traded_sell_signal", traded_sell_signal)
+                                return
                             }
+                            socket.emit("traded_sell_signal", traded_sell_signal)
                         }
                     )
                 } else {
@@ -789,14 +793,14 @@ socket.on("sell_signal", async (signal) => {
                                             Number(qty),
                                             JSON.stringify(error)
                                         )
-                                    } else {
-                                        console.log(
-                                            "SUCESS 71111111",
-                                            alt,
-                                            Number(qty)
-                                        )
-                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                        return
                                     }
+                                    console.log(
+                                        "SUCESS 71111111",
+                                        alt,
+                                        Number(qty)
+                                    )
+                                    socket.emit("traded_sell_signal", traded_sell_signal)
                                 }
                             )
                         } else {
@@ -818,14 +822,14 @@ socket.on("sell_signal", async (signal) => {
                                             Number(qty),
                                             JSON.stringify(error)
                                         )
-                                    } else {
-                                        console.log(
-                                            "SUCESS 711000111 marketSell",
-                                            alt + "BTC",
-                                            Number(qty)
-                                        )
-                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                        return
                                     }
+                                    console.log(
+                                        "SUCESS 711000111 marketSell",
+                                        alt + "BTC",
+                                        Number(qty)
+                                    )
+                                    socket.emit("traded_sell_signal", traded_sell_signal)
                                 }
                             )
                         }
@@ -903,9 +907,9 @@ socket.on("close_traded_signal", async (signal) => {
                                     Number(signal.qty),
                                     JSON.stringify(error)
                                 )
-                            } else {
-                                socket.emit("traded_sell_signal", traded_sell_signal)
+                                return
                             }
+                            socket.emit("traded_sell_signal", traded_sell_signal)
                         }
                     )
                 } else {
@@ -932,14 +936,14 @@ socket.on("close_traded_signal", async (signal) => {
                                             Number(qty),
                                             JSON.stringify(error)
                                         )
-                                    } else {
-                                        console.log(
-                                            "SUCESS44444",
-                                            alt,
-                                            Number(qty)
-                                        )
-                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                        return
                                     }
+                                    console.log(
+                                        "SUCESS44444",
+                                        alt,
+                                        Number(qty)
+                                    )
+                                    socket.emit("traded_sell_signal", traded_sell_signal)
                                 }
                             )
                         } else {
@@ -961,14 +965,14 @@ socket.on("close_traded_signal", async (signal) => {
                                             Number(qty),
                                             JSON.stringify(error)
                                         )
-                                    } else {
-                                        console.log(
-                                            "SUCESS 716611 marketSell",
-                                            alt,
-                                            Number(qty)
-                                        )
-                                        socket.emit("traded_sell_signal", traded_sell_signal)
+                                        return
                                     }
+                                    console.log(
+                                        "SUCESS 716611 marketSell",
+                                        alt,
+                                        Number(qty)
+                                    )
+                                    socket.emit("traded_sell_signal", traded_sell_signal)
                                 }
                             )
                         }
@@ -1020,26 +1024,26 @@ socket.on("close_traded_signal", async (signal) => {
                                     Number(signal.qty),
                                     error.body
                                 )
-                            } else {
-                                socket.emit("traded_buy_signal", traded_buy_signal)
-
-                                console.log("----- mgRepay BTC -----")
-                                bnb_client.mgRepay(
-                                    "BTC",
-                                    Number(signal.qty),
-                                    (error, response) => {
-                                        if (error) {
-                                            console.log(
-                                                "ERROR BTC 9",
-                                                Number(signal.qty),
-                                                error.body
-                                            )
-                                        } else {
-                                            console.log("SUCCESS BTC 8")
-                                        }
-                                    }
-                                )
+                                return
                             }
+                            socket.emit("traded_buy_signal", traded_buy_signal)
+
+                            console.log("----- mgRepay BTC -----")
+                            bnb_client.mgRepay(
+                                "BTC",
+                                Number(signal.qty),
+                                (error, response) => {
+                                    if (error) {
+                                        console.log(
+                                            "ERROR BTC 9",
+                                            Number(signal.qty),
+                                            error.body
+                                        )
+                                        return
+                                    }
+                                    console.log("SUCCESS BTC 8")
+                                }
+                            )
                         }
                     )
                 } else {
@@ -1060,29 +1064,29 @@ socket.on("close_traded_signal", async (signal) => {
                                         ),
                                         error.body
                                     )
-                                } else {
-                                    socket.emit("traded_buy_signal", traded_buy_signal)
-
-                                    console.log("----- mgRepay -----")
-                                    bnb_client.mgRepay(
-                                        alt,
-                                        Number(qty),
-                                        (error, response) => {
-                                            if (error) {
-                                                console.log(
-                                                    "ERROR 99999999999",
-                                                    alt,
-                                                    Number(qty),
-                                                    error.body
-                                                )
-                                            } else {
-                                                console.log(
-                                                    "SUCCESS 888888888888"
-                                                )
-                                            }
-                                        }
-                                    )
+                                    return
                                 }
+                                socket.emit("traded_buy_signal", traded_buy_signal)
+
+                                console.log("----- mgRepay -----")
+                                bnb_client.mgRepay(
+                                    alt,
+                                    Number(qty),
+                                    (error, response) => {
+                                        if (error) {
+                                            console.log(
+                                                "ERROR 99999999999",
+                                                alt,
+                                                Number(qty),
+                                                error.body
+                                            )
+                                            return
+                                        }
+                                        console.log(
+                                            "SUCCESS 888888888888"
+                                        )
+                                    }
+                                )
                             }
                         )
                     } else {


### PR DESCRIPTION
Stop sending signals to the BVA website before trading actually takes place. This can cause incorrect tracking when you do not operate for any reason.