### PR TITLE
Do after binance

### DIFF
--- a/src/trader.js
+++ b/src/trader.js
@@ -268,6 +268,16 @@ socket.on("buy_signal", async (signal) => {
                                 )
                                 return
                             }
+
+                            //////
+                            delete trading_pairs[signal.pair + signal.stratid]
+                            delete trading_types[signal.pair + signal.stratid]
+                            delete buy_prices[signal.pair + signal.stratid]
+                            delete sell_prices[signal.pair + signal.stratid]
+                            delete trading_qty[signal.pair + signal.stratid]
+                            delete open_trades[signal.pair + signal.stratid]
+                            //////
+
                             socket.emit(
                                 "traded_buy_signal",
                                 traded_buy_signal
@@ -295,20 +305,22 @@ socket.on("buy_signal", async (signal) => {
                     )
                 } else {
                     // VIRTUAL TRADE
+
+                    //////
+                    delete trading_pairs[signal.pair + signal.stratid]
+                    delete trading_types[signal.pair + signal.stratid]
+                    delete buy_prices[signal.pair + signal.stratid]
+                    delete sell_prices[signal.pair + signal.stratid]
+                    delete trading_qty[signal.pair + signal.stratid]
+                    delete open_trades[signal.pair + signal.stratid]
+                    //////
+
                     socket.emit("traded_buy_signal", traded_buy_signal)
                     notifier.notifyBuyToCoverTraded(signal);
                 }
             } else {
                 console.log("PAIR UNKNOWN", alt)
             }
-            //////
-            delete trading_pairs[signal.pair + signal.stratid]
-            delete trading_types[signal.pair + signal.stratid]
-            delete buy_prices[signal.pair + signal.stratid]
-            delete sell_prices[signal.pair + signal.stratid]
-            delete trading_qty[signal.pair + signal.stratid]
-            delete open_trades[signal.pair + signal.stratid]
-            //////
         } else {
             console.log(
                 "BUY AGAIN",

--- a/src/trader.js
+++ b/src/trader.js
@@ -663,6 +663,7 @@ socket.on("close_traded_signal", async (signal) => {
                                 delete trading_pairs[signal.pair + signal.stratid]
                                 delete trading_types[signal.pair + signal.stratid]
                                 delete sell_prices[signal.pair + signal.stratid]
+                                delete buy_prices[signal.pair + signal.stratid]
                                 delete trading_qty[signal.pair + signal.stratid]
                                 delete open_trades[signal.pair + signal.stratid]
                                 //////
@@ -700,6 +701,7 @@ socket.on("close_traded_signal", async (signal) => {
                                 delete trading_pairs[signal.pair + signal.stratid]
                                 delete trading_types[signal.pair + signal.stratid]
                                 delete sell_prices[signal.pair + signal.stratid]
+                                delete buy_prices[signal.pair + signal.stratid]
                                 delete trading_qty[signal.pair + signal.stratid]
                                 delete open_trades[signal.pair + signal.stratid]
                                 //////
@@ -728,6 +730,7 @@ socket.on("close_traded_signal", async (signal) => {
                 delete trading_pairs[signal.pair + signal.stratid]
                 delete trading_types[signal.pair + signal.stratid]
                 delete sell_prices[signal.pair + signal.stratid]
+                delete buy_prices[signal.pair + signal.stratid]
                 delete trading_qty[signal.pair + signal.stratid]
                 delete open_trades[signal.pair + signal.stratid]
                 //////
@@ -779,6 +782,7 @@ socket.on("close_traded_signal", async (signal) => {
                             //////
                             delete trading_pairs[signal.pair + signal.stratid]
                             delete trading_types[signal.pair + signal.stratid]
+                            delete sell_prices[signal.pair + signal.stratid]
                             delete buy_prices[signal.pair + signal.stratid]
                             delete trading_qty[signal.pair + signal.stratid]
                             delete open_trades[signal.pair + signal.stratid]
@@ -818,6 +822,7 @@ socket.on("close_traded_signal", async (signal) => {
                 //////
                 delete trading_pairs[signal.pair + signal.stratid]
                 delete trading_types[signal.pair + signal.stratid]
+                delete sell_prices[signal.pair + signal.stratid]
                 delete buy_prices[signal.pair + signal.stratid]
                 delete trading_qty[signal.pair + signal.stratid]
                 delete open_trades[signal.pair + signal.stratid]

--- a/src/trader.js
+++ b/src/trader.js
@@ -107,11 +107,6 @@ socket.on("buy_signal", async (signal) => {
             //notify
             notifier.notifyEnterLongSignal(signal)
 
-            //////
-            trading_pairs[signal.pair + signal.stratid] = true
-            trading_types[signal.pair + signal.stratid] = "LONG"
-            open_trades[signal.pair + signal.stratid] = true
-            //////
             console.log(
                 signal.pair,
                 " ===> BUY",
@@ -130,7 +125,6 @@ socket.on("buy_signal", async (signal) => {
                     minimums[alt + "BTC"].stepSize
                 )
                 console.log("Market Buy ==> " + qty + " - " + alt + "BTC")
-                trading_qty[signal.pair + signal.stratid] = Number(qty)
                 ////
                 const traded_buy_signal = {
                     key: bva_key,
@@ -151,6 +145,13 @@ socket.on("buy_signal", async (signal) => {
                                     console.log("ERROR 3355333", error.body)
                                     return
                                 }
+
+                                //////
+                                trading_pairs[signal.pair + signal.stratid] = true
+                                trading_types[signal.pair + signal.stratid] = "LONG"
+                                open_trades[signal.pair + signal.stratid] = true
+                                trading_qty[signal.pair + signal.stratid] = Number(qty)
+                                //////
 
                                 console.log("SUCCESS 222444222")
                                 socket.emit(
@@ -175,6 +176,13 @@ socket.on("buy_signal", async (signal) => {
                                     return
                                 }
 
+                                //////
+                                trading_pairs[signal.pair + signal.stratid] = true
+                                trading_types[signal.pair + signal.stratid] = "LONG"
+                                open_trades[signal.pair + signal.stratid] = true
+                                trading_qty[signal.pair + signal.stratid] = Number(qty)
+                                //////
+
                                 console.log(
                                     "SUCESS 99111 marketBuy",
                                     alt + "BTC",
@@ -190,6 +198,14 @@ socket.on("buy_signal", async (signal) => {
                     }
                 } else {
                     // VIRTUAL TRADE
+
+                    //////
+                    trading_pairs[signal.pair + signal.stratid] = true
+                    trading_types[signal.pair + signal.stratid] = "LONG"
+                    open_trades[signal.pair + signal.stratid] = true
+                    trading_qty[signal.pair + signal.stratid] = Number(qty)
+                    //////
+                    
                     socket.emit("traded_buy_signal", traded_buy_signal)
                     notifier.notifyEnterLongTraded(signal);
                 }

--- a/src/trader.js
+++ b/src/trader.js
@@ -489,6 +489,16 @@ socket.on("sell_signal", async (signal) => {
                                     )
                                     return
                                 }
+
+                                //////
+                                delete trading_pairs[signal.pair + signal.stratid]
+                                delete trading_types[signal.pair + signal.stratid]
+                                delete sell_prices[signal.pair + signal.stratid]
+                                delete buy_prices[signal.pair + signal.stratid]
+                                delete trading_qty[signal.pair + signal.stratid]
+                                delete open_trades[signal.pair + signal.stratid]
+                                //////
+
                                 console.log(
                                     "SUCESS 71111111",
                                     alt,
@@ -522,6 +532,16 @@ socket.on("sell_signal", async (signal) => {
                                     )
                                     return
                                 }
+
+                                //////
+                                delete trading_pairs[signal.pair + signal.stratid]
+                                delete trading_types[signal.pair + signal.stratid]
+                                delete sell_prices[signal.pair + signal.stratid]
+                                delete buy_prices[signal.pair + signal.stratid]
+                                delete trading_qty[signal.pair + signal.stratid]
+                                delete open_trades[signal.pair + signal.stratid]
+                                //////
+
                                 console.log(
                                     "SUCESS 711000111 marketSell",
                                     alt + "BTC",
@@ -537,6 +557,16 @@ socket.on("sell_signal", async (signal) => {
                     }
                 } else {
                     // VIRTUAL TRADE
+
+                    //////
+                    delete trading_pairs[signal.pair + signal.stratid]
+                    delete trading_types[signal.pair + signal.stratid]
+                    delete sell_prices[signal.pair + signal.stratid]
+                    delete buy_prices[signal.pair + signal.stratid]
+                    delete trading_qty[signal.pair + signal.stratid]
+                    delete open_trades[signal.pair + signal.stratid]
+                    //////
+
                     socket.emit("traded_sell_signal", traded_sell_signal)
                     notifier.notifyExitLongTraded(signal)
                 }
@@ -544,15 +574,6 @@ socket.on("sell_signal", async (signal) => {
             } else {
                 console.log("PAIR UNKNOWN", alt)
             }
-
-            //////
-            delete trading_pairs[signal.pair + signal.stratid]
-            delete trading_types[signal.pair + signal.stratid]
-            delete sell_prices[signal.pair + signal.stratid]
-            delete buy_prices[signal.pair + signal.stratid]
-            delete trading_qty[signal.pair + signal.stratid]
-            delete open_trades[signal.pair + signal.stratid]
-            //////
         } else {
             console.log(
                 "SELL AGAIN",

--- a/src/trader.js
+++ b/src/trader.js
@@ -582,7 +582,7 @@ socket.on("close_traded_signal", async (signal) => {
         if (trading_types[signal.pair + signal.stratid] === "LONG") {
             console.log(
                 colors.grey(
-                    "BUY_SIGNAL :: SELL TO EXIT LONG TRADE ::",
+                    "CLOSE_SIGNAL :: SELL TO EXIT LONG TRADE ::",
                     signal.stratname,
                     signal.stratid,
                     signal.pair

--- a/src/trader.js
+++ b/src/trader.js
@@ -205,7 +205,7 @@ socket.on("buy_signal", async (signal) => {
                     open_trades[signal.pair + signal.stratid] = true
                     trading_qty[signal.pair + signal.stratid] = Number(qty)
                     //////
-                    
+
                     socket.emit("traded_buy_signal", traded_buy_signal)
                     notifier.notifyEnterLongTraded(signal);
                 }
@@ -335,11 +335,7 @@ socket.on("sell_signal", async (signal) => {
             )
             //notify
             notifier.notifyEnterShortSignal(signal)
-            //////
-            trading_pairs[signal.pair + signal.stratid] = true
-            trading_types[signal.pair + signal.stratid] = "SHORT"
-            open_trades[signal.pair + signal.stratid] = true
-            //////
+            
             console.log(
                 signal.pair,
                 " ===> SELL",
@@ -358,7 +354,6 @@ socket.on("sell_signal", async (signal) => {
                     btc_qty,
                     minimums[alt + "BTC"].stepSize
                 )
-                trading_qty[signal.pair + signal.stratid] = Number(qty)
                 console.log(
                     "QTY ===mgBorrow===> " + qty + " - " + alt + "BTC"
                 )
@@ -385,6 +380,7 @@ socket.on("sell_signal", async (signal) => {
                                 )
                                 return
                             }
+
                             console.log(
                                 "SUCESS 444444444 mgMarketSell 44444444"
                             )
@@ -399,6 +395,14 @@ socket.on("sell_signal", async (signal) => {
                                         )
                                         return
                                     }
+
+                                    //////
+                                    trading_pairs[signal.pair + signal.stratid] = true
+                                    trading_types[signal.pair + signal.stratid] = "SHORT"
+                                    open_trades[signal.pair + signal.stratid] = true
+                                    trading_qty[signal.pair + signal.stratid] = Number(qty)
+                                    //////
+
                                     console.log("SUCCESS 22222222")
                                     socket.emit(
                                         "traded_sell_signal",
@@ -411,6 +415,14 @@ socket.on("sell_signal", async (signal) => {
                     )
                 } else {
                     // VIRTUAL TRADE
+
+                    //////
+                    trading_pairs[signal.pair + signal.stratid] = true
+                    trading_types[signal.pair + signal.stratid] = "SHORT"
+                    open_trades[signal.pair + signal.stratid] = true
+                    trading_qty[signal.pair + signal.stratid] = Number(qty)
+                    //////
+
                     socket.emit("traded_sell_signal", traded_sell_signal)
                     notifier.notifyEnterShortTraded(signal);
                 }

--- a/src/trader.js
+++ b/src/trader.js
@@ -625,6 +625,15 @@ socket.on("close_traded_signal", async (signal) => {
                                     )
                                     return
                                 }
+
+                                //////
+                                delete trading_pairs[signal.pair + signal.stratid]
+                                delete trading_types[signal.pair + signal.stratid]
+                                delete sell_prices[signal.pair + signal.stratid]
+                                delete trading_qty[signal.pair + signal.stratid]
+                                delete open_trades[signal.pair + signal.stratid]
+                                //////
+                                
                                 console.log("SUCESS44444", alt, Number(qty))
                                 socket.emit(
                                     "traded_sell_signal",
@@ -653,6 +662,15 @@ socket.on("close_traded_signal", async (signal) => {
                                     )
                                     return
                                 }
+
+                                //////
+                                delete trading_pairs[signal.pair + signal.stratid]
+                                delete trading_types[signal.pair + signal.stratid]
+                                delete sell_prices[signal.pair + signal.stratid]
+                                delete trading_qty[signal.pair + signal.stratid]
+                                delete open_trades[signal.pair + signal.stratid]
+                                //////
+
                                 console.log(
                                     "SUCESS 716611 marketSell",
                                     alt,
@@ -672,15 +690,17 @@ socket.on("close_traded_signal", async (signal) => {
 
             } else {
                 // VIRTUAL TRADE
+
+                //////
+                delete trading_pairs[signal.pair + signal.stratid]
+                delete trading_types[signal.pair + signal.stratid]
+                delete sell_prices[signal.pair + signal.stratid]
+                delete trading_qty[signal.pair + signal.stratid]
+                delete open_trades[signal.pair + signal.stratid]
+                //////
+
                 socket.emit("traded_sell_signal", traded_sell_signal)
             }
-            //////
-            delete trading_pairs[signal.pair + signal.stratid]
-            delete trading_types[signal.pair + signal.stratid]
-            delete sell_prices[signal.pair + signal.stratid]
-            delete trading_qty[signal.pair + signal.stratid]
-            delete open_trades[signal.pair + signal.stratid]
-            //////
         } else if (trading_types[signal.pair + signal.stratid] === "SHORT") {
             console.log(
                 colors.grey(
@@ -722,6 +742,15 @@ socket.on("close_traded_signal", async (signal) => {
                                 )
                                 return
                             }
+
+                            //////
+                            delete trading_pairs[signal.pair + signal.stratid]
+                            delete trading_types[signal.pair + signal.stratid]
+                            delete buy_prices[signal.pair + signal.stratid]
+                            delete trading_qty[signal.pair + signal.stratid]
+                            delete open_trades[signal.pair + signal.stratid]
+                            //////
+
                             socket.emit(
                                 "traded_buy_signal",
                                 traded_buy_signal
@@ -752,15 +781,17 @@ socket.on("close_traded_signal", async (signal) => {
 
             } else {
                 // VIRTUAL TRADE
+
+                //////
+                delete trading_pairs[signal.pair + signal.stratid]
+                delete trading_types[signal.pair + signal.stratid]
+                delete buy_prices[signal.pair + signal.stratid]
+                delete trading_qty[signal.pair + signal.stratid]
+                delete open_trades[signal.pair + signal.stratid]
+                //////
+
                 socket.emit("traded_buy_signal", traded_buy_signal)
             }
-            //////
-            delete trading_pairs[signal.pair + signal.stratid]
-            delete trading_types[signal.pair + signal.stratid]
-            delete buy_prices[signal.pair + signal.stratid]
-            delete trading_qty[signal.pair + signal.stratid]
-            delete open_trades[signal.pair + signal.stratid]
-            //////
         }
     }
 })


### PR DESCRIPTION
Only insert value on this variables after binance response. This is causing a lot of problems because the variables are updated before the binance response and can validate conditions even when trade does not occur.

`// VARIABLES TO KEEP TRACK OF BOT POSITIONS AND ACTIVITY`
`let trading_pairs = {}`
`let open_trades = {}`
`let trading_types = {}`
`let trading_qty = {}`