### PR TITLE
feat: add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "automerge": true,
+  "automergeType": "branch",
+  "docker": {
+    "major": {
+      "enabled": true
+    },
+    "pinDigests": true
+  },
+  "extends": [
+    "config:base",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "major": {
+    "automerge": false
+  }
+}


### PR DESCRIPTION
I use https://github.com/marketplace/renovate to keep the dependencies for all my projects up to date. GitHub actions supports something alike, but renovate is currently still more mature and supports more dependency types. For breaking changes, renovate will create a PR so that we're able to check.
@jsappme I'd propose the GitHub application to be added to this project. This will result in fairly frequent commits by the renovate bot, which might feel different from what one is used to, but doesn't really change anything except for the dependencies to be kept up to date (bug fixes, security fixes, ...). I'd understand if that's no needed though, as NBT does not run on a publicly available server and thus doesn't really *need* security updates. It's just an idea :)